### PR TITLE
fixed bug false winner and skipped winner

### DIFF
--- a/yt_api_test.py
+++ b/yt_api_test.py
@@ -53,7 +53,7 @@ def main():
 
     for text in comment_texts:
         # Test for if the secret password is found
-        pattern_password = rf"\b{re.escape(SECRET_PASSWORD)}[\s\n]"
+        pattern_password = rf"(?!\w){re.escape(SECRET_PASSWORD)}(?!\w)"
         if re.search(pattern_password, text):
             found = True
             print("\nFOUND SECRET PASSWORD\n")

--- a/yt_api_test.py
+++ b/yt_api_test.py
@@ -1,4 +1,5 @@
 import os
+import re
 
 import google_auth_oauthlib.flow
 import googleapiclient.discovery
@@ -52,7 +53,8 @@ def main():
 
     for text in comment_texts:
         # Test for if the secret password is found
-        if SECRET_PASSWORD.lower() in text.lower():
+        pattern_password = rf"\b{re.escape(SECRET_PASSWORD)}[\s\n]"
+        if re.search(pattern_password, text):
             found = True
             print("\nFOUND SECRET PASSWORD\n")
             with open("winner_info.txt", "w") as f:


### PR DESCRIPTION
ensuring that the password isn't in another word like nice in nicely and making sure it's separated from other words by anything but letters and numbers simple password like 'today ' wouldn't work as solution because 'today ' in 'nice day is today' returns false